### PR TITLE
Add system message style and increase paddings

### DIFF
--- a/components/ChatMessageRow.tsx
+++ b/components/ChatMessageRow.tsx
@@ -286,7 +286,7 @@ function ChatMessageRow({ message, previousMessage }: IProps): ReactElement {
           </div>
         </div>
       )}
-      <div className={styles.messageText}>
+      <div className={`${styles.messageText} ${isSystemMessage ? styles.systemMessage : ''}`}>
         <MessageText text={message.text} />
       </div>
     </div>

--- a/styles/Chat.module.scss
+++ b/styles/Chat.module.scss
@@ -8,15 +8,20 @@
   padding: 0.5rem;
 }
 
+.systemMessage {
+  background-color: #eff5ff;
+  border-radius: 8px;
+}
+
 .messageText {
-  padding-top: .2rem;
-  padding-bottom: .2rem;
+  padding: 0.4rem;
   white-space: pre-line;
 }
 
 .messageDetails {
   color: $secondary;
 
+  padding-left: 0.4rem;
   display: flex;
   flex-direction: row;
 }
@@ -26,12 +31,12 @@
 }
 
 .chatInputArea {
-  border-top: 1px solid rgba(0,0,0,.05);
+  border-top: 1px solid rgba(0, 0, 0, 0.05);
   padding: 0.5rem;
 }
 
 .disabledChatInputArea {
-  background: rgba(0,0,0,.03);
+  background: rgba(0, 0, 0, 0.03);
 }
 
 .chatTextArea {


### PR DESCRIPTION
I've added the styling for system messages. To make them look better as a "message bubble" I've added also a bit padding to the message row.

fixes #30 

My proposal: 
![image](https://user-images.githubusercontent.com/3205986/137644371-0a83e895-e8f5-4993-bf33-6e954f46ddb9.png)